### PR TITLE
Add support to list all reference related issues for swagger definitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <swagger.parser.version>2.1.12</swagger.parser.version>
-        <swagger.parser.v3.version>2.0.20</swagger.parser.v3.version>
+        <swagger.parser.v3.version>2.0.29</swagger.parser.v3.version>
         <slf4j.version>2.0.3</slf4j.version>
         <carbon.apimgt.version>9.0.174</carbon.apimgt.version>
         <log4j2.version>2.19.0</log4j2.version>
@@ -29,11 +28,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
-<!--        <dependency>-->
-<!--            <groupId>io.swagger</groupId>-->
-<!--            <artifactId>swagger-parser</artifactId>-->
-<!--            <version>${swagger.parser.version}</version>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <swagger.parser.v3.version>2.0.29</swagger.parser.v3.version>
+        <swagger.parser.v3.version>2.1.12</swagger.parser.v3.version>
         <slf4j.version>2.0.3</slf4j.version>
         <carbon.apimgt.version>9.0.174</carbon.apimgt.version>
         <log4j2.version>2.19.0</log4j2.version>

--- a/src/main/java/org/wso2/apim/swagger/tool/Constants.java
+++ b/src/main/java/org/wso2/apim/swagger/tool/Constants.java
@@ -36,6 +36,8 @@ public class Constants {
     public static final String UNABLE_TO_RENDER_THE_DEFINITION_ERROR = "Unable to render this definition, " +
             "The provided definition does not specify a valid version field.";
 
+    public static final String SCHEMA_REF_PATH = "#/components/schemas/";
+
     public enum SwaggerVersion {
         SWAGGER,
         OPEN_API,

--- a/src/main/java/org/wso2/apim/swagger/tool/SwaggerTool.java
+++ b/src/main/java/org/wso2/apim/swagger/tool/SwaggerTool.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.parser.Swagger20Parser;
+import io.swagger.parser.SwaggerParser;
 import io.swagger.v3.parser.ObjectMapperFactory;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.ParseOptions;
@@ -233,12 +234,13 @@ public class SwaggerTool {
 
     public static boolean swagger2Validator(String swagger, int validationLevel) {
         boolean isSwaggerMissing = false;
-        OpenAPIParser parser1 = new OpenAPIParser();
+        SwaggerParser swaggerParser = new SwaggerParser();
+        OpenAPIParser parser= new OpenAPIParser();
         ParseOptions options = new ParseOptions();
         options.setResolve(true);
         options.setFlatten(true);
         options.setResolveFully(true);
-        SwaggerParseResult parseAttemptForV2 = parser1.readContents(swagger, new ArrayList<>(), options);
+        SwaggerParseResult parseAttemptForV2 = parser.readContents(swagger, new ArrayList<>(), options);
         if (parseAttemptForV2.getMessages().size() > 0) {
             if (validationLevel == 1) {
                 StringBuilder errorMessageBuilder = new StringBuilder("Invalid OpenAPI, Error Code: ");
@@ -271,7 +273,7 @@ public class SwaggerTool {
                                 .append(", Error: ").append(Constants.OPENAPI_PARSE_EXCEPTION_ERROR_MESSAGE)
                                 .append(", Swagger Error: ").append(message);
                         try {
-//                            parser1.parse(swagger);
+                            swaggerParser.parse(swagger);
                             log.error(errorMessageBuilder.toString());
                         } catch (Exception e) {
                             errorMessageBuilder.append(", Cause by: ").append(e.getMessage());

--- a/src/main/java/org/wso2/apim/swagger/tool/SwaggerTool.java
+++ b/src/main/java/org/wso2/apim/swagger/tool/SwaggerTool.java
@@ -328,34 +328,44 @@ public class SwaggerTool {
                         log.error(errorMessageBuilder.toString());
                         isOpenAPIMissing = true;
                     } else {
-                        errorMessageBuilder.append(Constants.OPENAPI_PARSE_EXCEPTION_ERROR_CODE)
-                                .append(", Error: ").append(Constants.OPENAPI_PARSE_EXCEPTION_ERROR_MESSAGE)
-                                .append(", Swagger Error: ").append(message);
-                        log.error(errorMessageBuilder.toString());
+                        logOpenAPINotSupported(); // OpenAPI 3.0.0 is not supported with this iteration
+                        return isOpenAPIMissing;
+//                        errorMessageBuilder.append(Constants.OPENAPI_PARSE_EXCEPTION_ERROR_CODE)
+//                                .append(", Error: ").append(Constants.OPENAPI_PARSE_EXCEPTION_ERROR_MESSAGE)
+//                                .append(", Swagger Error: ").append(message);
+//                        log.error(errorMessageBuilder.toString());
                     }
                 }
             }
             if (!isOpenAPIMissing) {
-                if (parseResult.getOpenAPI() != null) {
-                    log.info("OpenAPI passed with errors, using may lead to functionality issues.");
-                    totalPartialyPasedSwaggerFiles++;
-                } else {
-                    log.error("Malformed OpenAPI, Please fix the listed issues before proceeding");
-                    ++totalMalformedSwaggerFiles;
-                }
-                if (validationLevel != 0) {
-                    validationFailedFileCount++;
-                }
+                logOpenAPINotSupported(); // OpenAPI 3.0.0 is not supported with this iteration
+                return isOpenAPIMissing;
+//                if (parseResult.getOpenAPI() != null) {
+//                    log.info("OpenAPI passed with errors, using may lead to functionality issues.");
+//                    totalPartialyPasedSwaggerFiles++;
+//                } else {
+//                    log.error("Malformed OpenAPI, Please fix the listed issues before proceeding");
+//                    ++totalMalformedSwaggerFiles;
+//                }
+//                if (validationLevel != 0) {
+//                    validationFailedFileCount++;
+//                }
             }
         } else {
             if (parseResult.getOpenAPI() != null) {
-                log.info("Swagger file is valid OpenAPI 3 definition");
-                validationSuccessFileCount++;
+                logOpenAPINotSupported(); // OpenAPI 3.0.0 is not supported with this iteration
+                return isOpenAPIMissing;
+//                log.info("Swagger file is valid OpenAPI 3 definition");
+//                validationSuccessFileCount++;
             } else {
                 log.error(Constants.UNABLE_TO_RENDER_THE_DEFINITION_ERROR);
                 validationFailedFileCount++;
             }
         }
         return isOpenAPIMissing;
+    }
+
+    public static void logOpenAPINotSupported() {
+        log.info("OpenAPI definition validation is not supported yet");
     }
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -10,6 +10,7 @@
     </Appenders>
     <Loggers>
         <Logger name="io.swagger.util" level="OFF" additivity="true"/>
+        <Logger name="io.swagger.v3" level="OFF" additivity="true"/>
         <Root level="INFO">
             <AppenderRef ref="ConsoleAppender"/>
             <AppenderRef ref="FileAppender"/>


### PR DESCRIPTION
## Purpose

- This PR adds the support to list all reference related issues for any given swagger definition as opposed to just picking the first reference issue and returning it as a validation failure.
 
- Also, a temporary fix is added to only validate swagger definitions and silently ignore OpenAPI definitions as ref issues are not picked up when structural errors are detected in the OpenAPI definition. If the definition is adhering to the specification, ref issues are picked, but if that is not the case, ref issues are not accurately picked. Till we decide how to move forward with this issue, temporarily OpenAPI definition validation is disabled.
